### PR TITLE
Fix typo in Risk Calculator

### DIFF
--- a/tutorials/borrowing-and-lending.md
+++ b/tutorials/borrowing-and-lending.md
@@ -38,7 +38,7 @@ Interest is paid on your borrows continuously from your deposits. Please monitor
 
 ## How to use the Risk Calculator 
 
-The Risk Calculator tool helps estimate liquidation scenarios on leveraged positioned. Liquidation events occur when your [Collateral Ratio](https://app.gitbook.com/@blockworksfoundation/s/mango/\~/drafts/-Mf9lVu8a9wqsacHHCGf/tutorials/trade-on-mango.markets#how-to-trade-with-leverage) drops below 110%. Since positions are cross-margined, there is not always a straight forward liquidation price to provide. With this tool, you can predict liquidations by providing assumptions on asset prices and other account details.
+The Risk Calculator tool helps estimate liquidation scenarios on leveraged positions. Liquidation events occur when your [Collateral Ratio](https://app.gitbook.com/@blockworksfoundation/s/mango/\~/drafts/-Mf9lVu8a9wqsacHHCGf/tutorials/trade-on-mango.markets#how-to-trade-with-leverage) drops below 110%. Since positions are cross-margined, there is not always a straight forward liquidation price to provide. With this tool, you can predict liquidations by providing assumptions on asset prices and other account details.
 
 Select 'Risk Calculator' below your account calculations.
 


### PR DESCRIPTION
Is this feature still in the UI? I don't see the "Risk Calculator" button from [the screenshot](https://docs.mango.markets/tutorials/borrowing-and-lending#how-to-use-the-risk-calculator).